### PR TITLE
Filter on Events, Community, and Ministry tab

### DIFF
--- a/CruCentralCoast/Community/CommunityGroups/CommunityGroupsVC.swift
+++ b/CruCentralCoast/Community/CommunityGroups/CommunityGroupsVC.swift
@@ -12,6 +12,16 @@ import RealmSwift
 class CommunityGroupsVC: UITableViewController {
     
     var dataArray: Results<CommunityGroup>!
+    var subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
+    
+    private lazy var emptyTableViewLabel: UILabel = {
+        let label = UILabel()
+        label.text = "No Community Groups"
+        label.font = UIFont.systemFont(ofSize: 24)
+        label.textColor = UIColor.lightGray
+        label.textAlignment = .center
+        return label
+    }()
         
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,7 +32,21 @@ class CommunityGroupsVC: UITableViewController {
         self.tableView.estimatedRowHeight = 140
         
         DatabaseManager.instance.subscribeToDatabaseUpdates(self)
-        self.dataArray = DatabaseManager.instance.getCommunityGroups()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.dataArray = DatabaseManager.instance.getCommunityGroups().filter("movement.id IN %@", self.subscribedMovements)
+        self.tableView.reloadData()
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        if self.dataArray.count == 0 {
+            self.tableView.backgroundView = self.emptyTableViewLabel
+            return 0
+        } else {
+            self.tableView.backgroundView = nil
+            return 1
+        }
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/CruCentralCoast/Community/CommunityGroups/CommunityGroupsVC.swift
+++ b/CruCentralCoast/Community/CommunityGroups/CommunityGroupsVC.swift
@@ -12,7 +12,6 @@ import RealmSwift
 class CommunityGroupsVC: UITableViewController {
     
     var dataArray: Results<CommunityGroup>!
-    var subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
     
     private lazy var emptyTableViewLabel: UILabel = {
         let label = UILabel()
@@ -35,7 +34,8 @@ class CommunityGroupsVC: UITableViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        self.dataArray = DatabaseManager.instance.getCommunityGroups().filter("movement.id IN %@", self.subscribedMovements)
+        let subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
+        self.dataArray = DatabaseManager.instance.getCommunityGroups().filter("movement.id IN %@", subscribedMovements)
         self.tableView.reloadData()
     }
     

--- a/CruCentralCoast/Community/MinistryTeams/MinistryTeamsVC.swift
+++ b/CruCentralCoast/Community/MinistryTeams/MinistryTeamsVC.swift
@@ -12,6 +12,16 @@ import RealmSwift
 class MinistryTeamsVC: UITableViewController {
     
     var dataArray: Results<MinistryTeam>!
+    var subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
+    
+    private lazy var emptyTableViewLabel: UILabel = {
+        let label = UILabel()
+        label.text = "No Ministry Teams"
+        label.font = UIFont.systemFont(ofSize: 24)
+        label.textColor = UIColor.lightGray
+        label.textAlignment = .center
+        return label
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,8 +35,23 @@ class MinistryTeamsVC: UITableViewController {
         self.dataArray = DatabaseManager.instance.getMinistryTeams()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        self.dataArray = DatabaseManager.instance.getMinistryTeams().filter("movement.id IN %@", self.subscribedMovements)
+        self.tableView.reloadData()
+    }
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.dataArray.count
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        if self.dataArray.count == 0 {
+            self.tableView.backgroundView = self.emptyTableViewLabel
+            return 0
+        } else {
+            self.tableView.backgroundView = nil
+            return 1
+        }
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/CruCentralCoast/Community/MinistryTeams/MinistryTeamsVC.swift
+++ b/CruCentralCoast/Community/MinistryTeams/MinistryTeamsVC.swift
@@ -12,7 +12,6 @@ import RealmSwift
 class MinistryTeamsVC: UITableViewController {
     
     var dataArray: Results<MinistryTeam>!
-    var subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
     
     private lazy var emptyTableViewLabel: UILabel = {
         let label = UILabel()
@@ -36,7 +35,8 @@ class MinistryTeamsVC: UITableViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        self.dataArray = DatabaseManager.instance.getMinistryTeams().filter("movement.id IN %@", self.subscribedMovements)
+        let subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
+        self.dataArray = DatabaseManager.instance.getMinistryTeams().filter("movement.id IN %@", subscribedMovements)
         self.tableView.reloadData()
     }
     

--- a/CruCentralCoast/Events/EventsVC.swift
+++ b/CruCentralCoast/Events/EventsVC.swift
@@ -17,7 +17,7 @@ class EventsVC: UITableViewController {
     
     private lazy var emptyTableViewLabel: UILabel = {
         let label = UILabel()
-        label.text = "No Community Groups"
+        label.text = "No Events"
         label.font = UIFont.systemFont(ofSize: 24)
         label.textColor = UIColor.lightGray
         label.textAlignment = .center

--- a/CruCentralCoast/Events/EventsVC.swift
+++ b/CruCentralCoast/Events/EventsVC.swift
@@ -11,9 +11,7 @@ import RealmSwift
 
 class EventsVC: UITableViewController {
     
-    
-    var dataArray = List<Event>()
-    var databaseArray: Results<Event>!
+    var dataArray: Results<Event>!
     
     private lazy var emptyTableViewLabel: UILabel = {
         let label = UILabel()
@@ -38,23 +36,7 @@ class EventsVC: UITableViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         let subscribedMovements = LocalStorage.preferences.getObject(forKey: .subscribedMovements) as? [String] ?? []
-        self.databaseArray = DatabaseManager.instance.getEvents()
-        
-        //reset the dataArray because I am appending it below.
-        self.dataArray.removeAll()
-        
-        self.databaseArray.forEach { (event) in
-            event.movements.forEach({ (movement) in
-                //check if the movement is in the subscribed movements and the dataArray does not already have the event to avoid repeats.
-                if subscribedMovements.contains(movement.id) && !self.dataArray.contains(event){
-                    self.dataArray.append(event)
-                    //return since at least one movement from the event is in the subscribed movements.
-                    return
-                }
-            })
-        }
-        
-        //reload the data in the tableview.
+        self.dataArray = DatabaseManager.instance.getEvents().filter("ANY movements.id IN %@", subscribedMovements)
         self.tableView.reloadData()
     }
     


### PR DESCRIPTION
I added a filter to the Event, Community, and Ministry Tab. When you go change your subscribed campus or movement in the profile screen, the tabs will all be automatically updated to the campuses you choose.